### PR TITLE
Add releases file as it should live here rather than in the stackablectl repo

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,0 +1,94 @@
+---
+releases:
+  22.05-sbernauer:
+    releaseDate: 2022-05-06
+    description: Non-offical release from sbernauer to demonstrate stackablectl. It includes the latest stable versions.
+    products:
+      airflow:
+        operatorVersion: 0.2.0
+      commons:
+        operatorVersion: 0.1.0
+      druid:
+        operatorVersion: 0.5.0
+      hbase:
+        operatorVersion: 0.2.0
+      hdfs:
+        operatorVersion: 0.3.0
+      hive:
+        operatorVersion: 0.5.0
+      kafka:
+        operatorVersion: 0.5.0
+      nifi:
+        operatorVersion: 0.5.0
+      opa:
+        operatorVersion: 0.8.0
+      secret:
+        operatorVersion: 0.3.0
+      spark:
+        operatorVersion: 0.5.0
+      spark-k8s:
+        operatorVersion: 0.1.0
+      superset:
+        operatorVersion: 0.4.0
+      trino:
+        operatorVersion: 0.3.1
+      zookeeper:
+        operatorVersion: 0.9.0
+  alpha-3:
+    releaseDate: 2022-02-14
+    description: Second release which added Airflow, Druid and Superset
+    products:
+      airflow:
+        operatorVersion: 0.2.0
+      druid:
+        operatorVersion: 0.4.0
+      hbase:
+        operatorVersion: 0.2.0
+      hdfs:
+        operatorVersion: 0.3.0
+      hive:
+        operatorVersion: 0.5.0
+      kafka:
+        operatorVersion: 0.5.0
+      nifi:
+        operatorVersion: 0.5.0
+      opa:
+        operatorVersion: 0.8.0
+      regorule:
+        operatorVersion: 0.6.0
+      secret:
+        operatorVersion: 0.2.0
+      spark:
+        operatorVersion: 0.5.0
+      superset:
+        operatorVersion: 0.3.0
+      trino:
+        operatorVersion: 0.3.1
+      zookeeper:
+        operatorVersion: 0.9.0
+  alpha-2:
+    releaseDate: 2021-10-29
+    description: First release of the Stackable Data Platform
+    products:
+      hbase:
+        operatorVersion: 0.1.0
+      hdfs:
+        operatorVersion: 0.1.0
+      hive:
+        operatorVersion: 0.1.0
+      kafka:
+        operatorVersion: 0.3.0
+      monitoring:
+        operatorVersion: 0.3.0
+      nifi:
+        operatorVersion: 0.3.0
+      opa:
+        operatorVersion: 0.4.1
+      regorule:
+        operatorVersion: 0.2.0
+      spark:
+        operatorVersion: 0.3.0
+      trino:
+        operatorVersion: 0.1.0
+      zookeeper:
+        operatorVersion: 0.4.1


### PR DESCRIPTION
Currently the release.yaml which is the machine readable release description used by stackablectl resides in the stackablectl repository.
As this will be the "official" source for releases we should move this file over here.

I will create a PR to add a deprecation note to that repositories file in parallel.