### PR TITLE
Update trino-operator to 0.6.0 in release 22.09

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -29,7 +29,7 @@ releases:
       superset:
         operatorVersion: 0.6.0
       trino:
-        operatorVersion: 0.5.0
+        operatorVersion: 0.6.0
       zookeeper:
         operatorVersion: 0.11.0
   22.06:


### PR DESCRIPTION
As approved in https://github.com/stackabletech/trino-operator/pull/278