### PR TITLE
chore: Update 24.11 release to use 24.11.1 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ The information is available in a machine-readable form in [releases.yaml](https
 
 The following releases are available:
 
-- 2024-11
-- 2024-07
-- 2024-03
-- 2023-11
-- 2023-07
-- 2023-04
-- 2023-01
-- 2022-11
-- 2022-09
-- 2022-06
+- 24.11
+- 24.7
+- 24.3
+- 23.11
+- 23.7
+- 23.4
+- 23.1
+- 22.11
+- 22.9
+- 22.6
 
 Take a look at the [release notes](https://docs.stackable.tech/home/stable/release_notes.html) for details.

--- a/releases.yaml
+++ b/releases.yaml
@@ -5,37 +5,37 @@ releases:
     description: The November 2024 release
     products: &latest-release-products
       airflow:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       commons:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       druid:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       hbase:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       hdfs:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       hello-world:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       hive:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       kafka:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       listener:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       nifi:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       opa:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       secret:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       spark-k8s:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       superset:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       trino:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
       zookeeper:
-        operatorVersion: 24.11.0
+        operatorVersion: 24.11.1
 
   24.7:
     releaseDate: 2024-07-24


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/683